### PR TITLE
Fix behavior of by.None in metadata engine

### DIFF
--- a/metadata/query.go
+++ b/metadata/query.go
@@ -105,9 +105,9 @@ func toSearchBy(by aur.By) []string {
 	case aur.NameDesc:
 		return []string{"Name", "Description"}
 	case aur.None:
-		return []string{"Name", "Provides[]?"}
+		return []string{"Name", "Description"}
 	case aur.Provides:
-		return []string{"Provides[]?"}
+		return []string{"Name", "Provides[]?"}
 	case aur.Maintainer:
 		return []string{"Maintainer"}
 	case aur.Submitter:

--- a/metadata/query_test.go
+++ b/metadata/query_test.go
@@ -107,6 +107,7 @@ func TestGet(t *testing.T) {
 				Contains: false,
 			},
 			expectedNames: []string{
+				"yay",
 				"yay-bin",
 				"yay-git",
 			},
@@ -118,7 +119,7 @@ func TestGet(t *testing.T) {
 				Needles:  []string{"WIREGUARD-MODULE"},
 				Contains: false,
 			},
-			expectedNames: []string{"linux-amd-git", "linux-ath-dfs"},
+			expectedNames: []string{},
 		},
 		{
 			desc: "Maintainer",


### PR DESCRIPTION
Fix behavior of by.None in metadata engine to match Name desc instead of provides